### PR TITLE
comment out "holiday closure alert banner"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,18 +43,19 @@
       </ul>
   </nav>
 
-       <!-- Holiday / Closure Section -->
-        <h5 class="alert">
-            We will be closed from Monday, July 16, 2018 to Monday, July 23, 2018.
-            <!--
-            <ul>
-              <li>Thursday, November 23, 2017</li>
-              <li>Friday, November 24, 2017 </li>
-              <li>Monday, November 27, 2017</li>
-            </ul>
-            -->
-            We will re-open Tuesday, July 24, 2018. We apologize for the inconvenience. The best way to contact us during this time is via e-mail: <a href="mailto:quyenchangdds@gmail.com">quyenchangdds@gmail.com</a>, or you can call us at <a href="tel:19197836551">919-783-6551</a> and leave a message - we will check them periodically.</li>
-        </h5>
-<!--       -->
+  {% comment %}
+    <!-- Holiday / Closure Section -->
+    <h5 class="alert">
+        We will be closed from Monday, July 16, 2018 to Monday, July 23, 2018.
+        <!--
+        <ul>
+          <li>Thursday, November 23, 2017</li>
+          <li>Friday, November 24, 2017 </li>
+          <li>Monday, November 27, 2017</li>
+        </ul>
+        -->
+        We will re-open Tuesday, July 24, 2018. We apologize for the inconvenience. The best way to contact us during this time is via e-mail: <a href="mailto:quyenchangdds@gmail.com">quyenchangdds@gmail.com</a>, or you can call us at <a href="tel:19197836551">919-783-6551</a> and leave a message - we will check them periodically.</li>
+    </h5>
+  {% endcomment %}
 
 </header>


### PR DESCRIPTION
the comment way, {% comment %}, skips over the block so that it doesn't output into the html.
vs. the html comment way, it outputs into the html but just doesn't get shown.