### PR TITLE
fix: update thanksgiving 2020 header message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 .sass-cache
+.jekyll-cache

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+
+## install steps
+- https://jekyllrb.com/docs/installation/macos/
+
+
+## app start up
+- refer to notes in `_config.yml`
+  `jekyll serve --baseurl ''` --> for prod, when you want the root path as "/"
+  `jekyll serve` --> daily dev use

--- a/_includes/alerts/covid19-reopen.html
+++ b/_includes/alerts/covid19-reopen.html
@@ -1,5 +1,5 @@
 <h5 class="alert alert-info">
   <p>
-  Our office is now open and seeing all patients! Check our blog for more information - <a href="{{site.baseurl}}/blog/2020/05/22/covid-19-updates.html" style="color:red;">COVID-19 Updates</a>
+  Check our blog to read our important <a href="{{site.baseurl}}/blog/2020/05/22/covid-19-updates.html" style="color:red;">COVID-19 protocol updates</a> for your upcoming appointment.
   </p>
 </h5>

--- a/_includes/alerts/misc.html
+++ b/_includes/alerts/misc.html
@@ -1,0 +1,12 @@
+<h5 class="alert alert-red">
+  We will be closing at 12 PM on Thursday, September 13, 2018 and will close all day Friday, September 14, 2018 due to Hurricane Florence. We apologize for the inconvenience, and hope everyone stays safe.
+  We will be closed from Monday, July 16, 2018 to Monday, July 23, 2018.
+    <!--
+    <ul>
+      <li>Thursday, November 23, 2017</li>
+      <li>Friday, November 24, 2017 </li>
+      <li>Monday, November 27, 2017</li>
+    </ul>
+    -->
+  We will re-open Tuesday, July 24, 2018. We apologize for the inconvenience. The best way to contact us during this time is via e-mail: <a href="mailto:{{site.email}}">{{site.email}}</a>, or you can call us at <a href="tel:19197836551">919-783-6551</a> and leave a message - we will check them periodically.</li>
+</h5>

--- a/_includes/alerts/thanksgiving.html
+++ b/_includes/alerts/thanksgiving.html
@@ -1,12 +1,16 @@
-<h5 class="alert alert-red">
-  We will be closing at 12 PM on Thursday, September 13, 2018 and will close all day Friday, September 14, 2018 due to Hurricane Florence. We apologize for the inconvenience, and hope everyone stays safe.
-  We will be closed from Monday, July 16, 2018 to Monday, July 23, 2018.
-    <!--
-    <ul>
-      <li>Thursday, November 23, 2017</li>
-      <li>Friday, November 24, 2017 </li>
-      <li>Monday, November 27, 2017</li>
-    </ul>
-    -->
-  We will re-open Tuesday, July 24, 2018. We apologize for the inconvenience. The best way to contact us during this time is via e-mail: <a href="mailto:{{site.email}}">{{site.email}}</a>, or you can call us at <a href="tel:19197836551">919-783-6551</a> and leave a message - we will check them periodically.</li>
+<h5 class="alert alert-info">
+  We will be closed the following days for the Thanksgiving holiday:
+  <ul style="padding: 10px 40px;">
+    <li>Wednesday, November 25, 2020</li>
+    <li>Thursday, November 26, 2020</li>
+    <li>Friday, November 27, 2020 </li>
+    <li>Monday, November 30, 2020</li>
+  </ul>
+  We will re-open Tuesday, December 1, 2020.
+  <p>
+  The best way to contact us during this time is via e-mail: <a href="mailto:quyenchangdds@gmail.com">quyenchangdds@gmail.com</a>.
+  </p>
+  <p>
+  We hope you have a Happy Thanksgiving!
+  </p>
 </h5>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -49,5 +49,6 @@
     {% include alerts/covid19.html %}
   {% endcomment %}
 
+  {% include alerts/thanksgiving.html %}
   {% include alerts/covid19-reopen.html %}
 </header>


### PR DESCRIPTION
refer to old thanksgiving template: https://github.com/gabrielyeung/changdds/commit/505f455a0d395286f5241a4042efee68262528c3#diff-7487918e4348c5078ee961c1ac01e342a7ca67f5111f891349f4b44b54c42d24

new screenshots:
mobile/desktop

<img width="517" alt="Screen Shot 2020-11-16 at 11 37 25 AM" src="https://user-images.githubusercontent.com/3629900/99299621-4f458800-2800-11eb-9307-0d6acce52a1f.png">
<img width="946" alt="Screen Shot 2020-11-16 at 11 37 38 AM" src="https://user-images.githubusercontent.com/3629900/99299626-52d90f00-2800-11eb-9ebf-06deb57269af.png">
